### PR TITLE
CLI changes for ExtractUserIDFromIDToken changes

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -935,20 +935,23 @@ const expectedAwsStsEndpoint = "https://sts.amazonaws.com"
 func TestCanUpdateAWSCredentialsInDefaultCredFile(t *testing.T) {
 	cfgFile := filepath.Join(os.Getenv("HOME"), ".aws/credentials")
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "priam").Return(nil)
+	tokenServiceMock.On("ExtractUserIDFromIDToken", mock.Anything, goodIdToken).Return("salo")
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "priam", "salo").Return(nil)
 	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "space-hound")
 }
 
 func TestCanUpdateAWSCredentialsInExplicitCredFile(t *testing.T) {
 	cfgFile := "/var/tmp/my-cred-file"
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-messenger", expectedAwsStsEndpoint, cfgFile, "priam").Return(nil)
+	tokenServiceMock.On("ExtractUserIDFromIDToken", mock.Anything, goodIdToken).Return("salo")
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-messenger", expectedAwsStsEndpoint, cfgFile, "priam", "salo").Return(nil)
 	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "-c", cfgFile, "space-messenger")
 }
 
 func TestCanUpdateAWSCredentialsInExplicitCredFileAndProfile(t *testing.T) {
 	cfgFile := "/var/tmp/my-cred-file"
 	tokenServiceMock := setupTokenServiceMock()
-	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "kazak").Return(nil)
+	tokenServiceMock.On("ExtractUserIDFromIDToken", mock.Anything, goodIdToken).Return("salo")
+	tokenServiceMock.On("UpdateAWSCredentials", mock.Anything, goodIdToken, "space-hound", expectedAwsStsEndpoint, cfgFile, "kazak", "salo").Return(nil)
 	testMockCommand(t, &tokenServiceMock.Mock, "token", "aws", "-c", cfgFile, "-p", "kazak", "space-hound")
 }


### PR DESCRIPTION
Modified token.go to create an ExtractUserIDFromIDToken function that gets the user ID of form similar to '@'. After aquiring a session token, can use the aws sts get-caller-identity --profile --region command to see the actual Account info, the UserId, and Arn value that the user will assume.